### PR TITLE
bug(issue-97): return error code 0 on -v

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -97,7 +97,7 @@ int main(int argc, char *argv[]) {
                 break;
             case 'v':
                 printVersion();
-                break;
+                return 0;
             case 'h':
                 printHelp();
                 return 0;


### PR DESCRIPTION
This PR will return an error code 0 when successfully outputting the version information.