### PR TITLE
Fix .align and .ds before .incbin

### DIFF
--- a/src/assemble.c
+++ b/src/assemble.c
@@ -863,6 +863,10 @@ void handle_asm_incbin(void) {
         address += ci->size;
     }
     if(pass == ENDPASS) {
+        // .ds and .align defer their fill bytes until the next output byte.
+        // Flush them before incbin's direct-write paths bypass emit_8bit().
+        if(ci->size) ioFlushDSSpaces();
+
         if(completefilebuffering) {
             if(listing) { // Output needs to pass to the listing through emit_8bit, performance-hit
                 for(n = 0; n < ci->size; n++) emit_8bit(ci->buffer[n]);

--- a/src/io.c
+++ b/src/io.c
@@ -204,15 +204,19 @@ void ioClose(void) {
     _deleteFiles();
 }
 
+void ioFlushDSSpaces(void) {
+    if(pass != ENDPASS) return;
+
+    if(listing && remaining_dsspaces) listPrintDSLines(remaining_dsspaces, fillbyte);
+    while(remaining_dsspaces) {
+        io_outputc(fillbyte);
+        remaining_dsspaces--;
+    }
+}
+
 void emit_8bit(uint8_t value) {
     if(pass == ENDPASS) {
-        if(remaining_dsspaces) {
-            if(listing) listPrintDSLines(remaining_dsspaces, fillbyte);
-            while(remaining_dsspaces) {
-                io_outputc(fillbyte);
-                remaining_dsspaces--;
-            }
-        }
+        ioFlushDSSpaces();
         if(listing) listEmit8bit(value);
         io_outputc(value);
     }

--- a/src/io.h
+++ b/src/io.h
@@ -19,6 +19,7 @@ bool ioInit(const char *input_filename, const char *output_filename); // init - 
 void ioClose(void);                                // close everything at end, do cleanup
 void ioPutc(uint8_t fh, unsigned char c);          // buffered write of a single byte / fallback
 int  ioPuts(uint8_t fh, const char *s);                  // buffered write of a string / fallback
+void ioFlushDSSpaces(void);
 void emit_8bit(uint8_t value);
 void emit_16bit(uint16_t value);
 void emit_24bit(uint24_t value);

--- a/tests/Addressing/test.sh
+++ b/tests/Addressing/test.sh
@@ -29,6 +29,26 @@ for FILE in *; do
                         echo " match"
                         tests_successfull=$((tests_successfull+1))
                     fi
+                elif [ "$FILE" == "align_incbin.s" ]; then
+                    echo -n " - aligned incbin"
+                    if [ "$(wc -c < align_incbin.bin)" -eq 268 ] &&
+                       [ "$(od -An -v -tu1 -j1 -N255 align_incbin.bin | tr -s ' ' '\n' | grep -c '^255$')" -eq 255 ] &&
+                       cmp -s <(tail -c 12 align_incbin.bin) incbin_data.inc; then
+                        echo " match"
+                        tests_successfull=$((tests_successfull+1))
+                    else
+                        echo " error"
+                    fi
+                elif [ "$FILE" == "ds_incbin.s" ]; then
+                    echo -n " - reserved incbin"
+                    if [ "$(wc -c < ds_incbin.bin)" -eq 16 ] &&
+                       [ "$(od -An -v -tu1 -j1 -N3 ds_incbin.bin | tr -s ' ' '\n' | grep -c '^255$')" -eq 3 ] &&
+                       cmp -s <(tail -c 12 ds_incbin.bin) incbin_data.inc; then
+                        echo " match"
+                        tests_successfull=$((tests_successfull+1))
+                    else
+                        echo " error"
+                    fi
                 else
                     echo ""
                     tests_successfull=$((tests_successfull+1))

--- a/tests/Addressing/tests/align_incbin.s
+++ b/tests/Addressing/tests/align_incbin.s
@@ -1,0 +1,3 @@
+        db 0
+        align 0x100
+        incbin "incbin_data.inc"

--- a/tests/Addressing/tests/ds_incbin.s
+++ b/tests/Addressing/tests/ds_incbin.s
@@ -1,0 +1,3 @@
+        db 0
+        ds 3
+        incbin "incbin_data.inc"

--- a/tests/Addressing/tests/incbin_data.inc
+++ b/tests/Addressing/tests/incbin_data.inc
@@ -1,0 +1,1 @@
+Hello world


### PR DESCRIPTION
## What changed

- Flush deferred `.align` and `.ds` fill bytes before a non-empty `.incbin` writes directly to the output buffer.
- Reuse the same flush routine from `emit_8bit()`.
- Add regression coverage for both `.align` followed by `.incbin` and `.ds` followed by `.incbin`.

## Root cause

`.align` and `.ds` defer their fill bytes until the next emitted byte. The optimized `.incbin` paths write directly to the output buffer and bypassed `emit_8bit()`, so the deferred fill bytes were omitted.

## Impact

Included binary data now begins at the address calculated during both assembly passes. Existing behavior for trailing `.align` or `.ds` at end of file remains unchanged.

## Validation

- Full repository test suite passes.
- Regression cases pass with complete file buffering enabled.
- The reported case and `.ds` variant pass through the streaming `.incbin` path as well.
